### PR TITLE
Align ABIs and backend scripts for Freaks2

### DIFF
--- a/public/erc20Abi.json
+++ b/public/erc20Abi.json
@@ -5,7 +5,9 @@
       { "internalType": "address", "name": "spender", "type": "address" }
     ],
     "name": "allowance",
-    "outputs": [ { "internalType": "uint256", "name": "", "type": "uint256" } ],
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -15,21 +17,29 @@
       { "internalType": "uint256", "name": "value", "type": "uint256" }
     ],
     "name": "approve",
-    "outputs": [ { "internalType": "bool", "name": "", "type": "bool" } ],
+    "outputs": [
+      { "internalType": "bool", "name": "", "type": "bool" }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [ { "internalType": "address", "name": "spender", "type": "address" } ],
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
     "name": "balanceOf",
-    "outputs": [ { "internalType": "uint256", "name": "", "type": "uint256" } ],
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "decimals",
-    "outputs": [ { "internalType": "uint8", "name": "", "type": "uint8" } ],
+    "outputs": [
+      { "internalType": "uint8", "name": "", "type": "uint8" }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -39,7 +49,9 @@
       { "internalType": "uint256", "name": "value", "type": "uint256" }
     ],
     "name": "transfer",
-    "outputs": [ { "internalType": "bool", "name": "", "type": "bool" } ],
+    "outputs": [
+      { "internalType": "bool", "name": "", "type": "bool" }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -50,7 +62,9 @@
       { "internalType": "uint256", "name": "value", "type": "uint256" }
     ],
     "name": "transferFrom",
-    "outputs": [ { "internalType": "bool", "name": "", "type": "bool" } ],
+    "outputs": [
+      { "internalType": "bool", "name": "", "type": "bool" }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   }

--- a/public/freakyFridayGameAbi.json
+++ b/public/freakyFridayGameAbi.json
@@ -1,5 +1,59 @@
 [
   {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true,  "internalType": "address", "name": "user",   "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "round",  "type": "uint256" }
+    ],
+    "name": "Joined",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true,  "internalType": "address", "name": "winner", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "round",  "type": "uint256" }
+    ],
+    "name": "RoundCompleted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint8", "name": "newMode", "type": "uint8" }
+    ],
+    "name": "RoundModeChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "sender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Received",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true,  "internalType": "address", "name": "user",  "type": "address" },
+      { "indexed": true,  "internalType": "uint256", "name": "round", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "RefundClaimed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true,  "internalType": "address", "name": "caller", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "CloseTipPaid",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "stateMutability": "nonpayable",
     "type": "constructor"

--- a/ritual-bot.js
+++ b/ritual-bot.js
@@ -2,9 +2,8 @@
   ritual-bot.js
 
   A simple script that checks whether the current round has expired and,
-  if so, calls the on‑chain `checkTimeExpired()` method.  Run this on a
-  schedule (e.g. with cron or `npm run bot`) to ensure rounds are closed
-  promptly when their duration elapses.
+  if so, calls the on‑chain `checkTimeExpired()` method. It can run once as
+  a cron job or loop periodically as a background worker.
 
   Usage:
     node ritual-bot.js
@@ -19,9 +18,12 @@ const abi = require('./public/freakyFridayGameAbi.json');
 
 const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
 const signer   = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
-const game    = new ethers.Contract(process.env.FREAKY_ADDRESS, abi, signer);
+const game     = new ethers.Contract(process.env.FREAKY_ADDRESS, abi, signer);
 
-async function main() {
+const LOOP_SECONDS = Number(process.env.LOOP_SECONDS || 60);
+const ONE_SHOT = process.env.ONE_SHOT === 'true';
+
+async function checkRound() {
   try {
     const isActive = await game.isRoundActive();
     if (!isActive) {
@@ -34,17 +36,25 @@ async function main() {
     ]);
     const now = Math.floor(Date.now() / 1000);
     const expiry = Number(start) + Number(duration);
-    if (now >= expiry) {
-      console.log('Round has expired; submitting checkTimeExpired transaction...');
-      const tx = await game.checkTimeExpired();
-      await tx.wait();
-      console.log('✅ Round closed; tx hash:', tx.hash);
-    } else {
-      console.log('Round still active.  Seconds remaining:', expiry - now);
+    if (now < expiry) {
+      console.log('Not expired yet. Seconds remaining:', expiry - now);
+      return;
     }
+    // Dry run to ensure the transaction will succeed
+    await game.checkTimeExpired.staticCall();
+    const tx = await game.checkTimeExpired();
+    await tx.wait();
+    console.log('✅ Round closed; tx hash:', tx.hash);
   } catch (err) {
     console.error('Error while checking round:', err.message || err);
   }
 }
 
-main().then(() => process.exit(0));
+async function run() {
+  await checkRound();
+  if (!ONE_SHOT) {
+    setTimeout(run, LOOP_SECONDS * 1000);
+  }
+}
+
+run();

--- a/ritual-relayer.js
+++ b/ritual-relayer.js
@@ -21,7 +21,8 @@ const cors    = require('cors');
 const { ethers } = require('ethers');
 
 const app = express();
-app.use(cors({ origin: process.env.FRONTEND_URL || '*' }));
+const allowedOrigin = process.env.FRONTEND_URL || 'http://localhost:3000';
+app.use(cors({ origin: allowedOrigin }));
 app.use(express.json());
 
 // Load ABIs.  These are generated from the JSON files in ./public by build-abi.js.
@@ -34,7 +35,7 @@ const signer   = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
 
 // Construct contract instances
 const gameAddress = process.env.FREAKY_ADDRESS;
-const tokenAddress = process.env.GCC_ADDRESS;
+const tokenAddress = process.env.GCC_TOKEN || process.env.GCC_ADDRESS;
 const gameContract = new ethers.Contract(gameAddress, gameAbi, signer);
 const tokenContract = new ethers.Contract(tokenAddress, erc20Abi, provider);
 


### PR DESCRIPTION
## Summary
- expose full ERC20 ABI for frontend balance/approval checks
- include game events in ABI for winner updates
- tighten relayer CORS and env naming
- enhance round-closure bot with loop/dry-run logic

## Testing
- `node --check ritual-relayer.js`
- `node --check ritual-bot.js`
- `jq length public/erc20Abi.json`
- `jq length public/freakyFridayGameAbi.json`


------
https://chatgpt.com/codex/tasks/task_e_68a79edeb5e0832bb9dc6bcd35518183