### PR TITLE
chore(bot+cors): safe close w/ staticCall + Sydney timestamps; confirm CORS for frontend

### DIFF
--- a/build-abi.js
+++ b/build-abi.js
@@ -1,16 +1,13 @@
-// build-abi.js for Freaks2Backend
-// This script converts our JSON ABI definitions into ES module files.  The
-// front‑end and backend both import these modules to get typed ABI arrays.
-const fs = require('fs');
+import fs from 'fs';
 
 const files = [
   { json: './public/freakyFridayGameAbi.json', out: './public/freakyFridayGameAbi.js' },
   { json: './public/erc20Abi.json', out: './public/erc20Abi.js' }
 ];
 
-files.forEach(({ json, out }) => {
+for (const { json, out } of files) {
   const abi = JSON.parse(fs.readFileSync(json, 'utf8'));
-  const js  = `module.exports = ${JSON.stringify(abi, null, 2)};\n`;
+  const js  = `export default ${JSON.stringify(abi, null, 2)};\n`;
   fs.writeFileSync(out, js);
   console.log('✅ Generated', out);
-});
+}

--- a/mode-scheduler.js
+++ b/mode-scheduler.js
@@ -1,38 +1,23 @@
-/*
-  mode-scheduler.js
-
-  This script automatically flips the FreakyFriday game’s prize mode based on
-  the day of the week in the configured timezone.  On Fridays (weekday 5 in
-  ISO‑8601), the mode is set to Jackpot (1); on all other days it is set to
-  Standard (0).  The mode is only changed when no round is active.
-
-  Run this script as a long‑lived process (e.g. via npm run scheduler).  It
-  schedules itself to run once per hour, but you can adjust the cron
-  expression below to suit your needs.
-*/
-
-require('dotenv').config();
-const cron = require('node-cron');
-const { DateTime } = require('luxon');
-const { ethers } = require('ethers');
-
-const abi = require('./public/freakyFridayGameAbi.json');
+import 'dotenv/config';
+import cron from 'node-cron';
+import { DateTime } from 'luxon';
+import { ethers } from 'ethers';
+import abi from './public/freakyFridayGameAbi.json' assert { type: 'json' };
 
 const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
 const signer   = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
-const game    = new ethers.Contract(process.env.FREAKY_ADDRESS, abi, signer);
+const game     = new ethers.Contract(process.env.FREAKY_ADDRESS, abi, signer);
 
 const PrizeMode = { Standard: 0, Jackpot: 1 };
 
 async function flipModeIfNeeded() {
   try {
     const active = await game.isRoundActive();
-    if (active) return; // never flip mid‑round
+    if (active) return;
     const tz = process.env.TIMEZONE || 'Australia/Sydney';
     const now = DateTime.now().setZone(tz);
-    const isFriday = now.weekday === 5; // ISO weekday: 1 = Monday, 5 = Friday
+    const isFriday = now.weekday === 5;
     const desired = isFriday ? PrizeMode.Jackpot : PrizeMode.Standard;
-    // Prefer explicit getter; fallback to public var
     const current = await (game.getRoundMode ? game.getRoundMode() : game.roundMode());
     if (Number(current) !== desired) {
       const tx = await game.setRoundMode(desired);
@@ -44,12 +29,9 @@ async function flipModeIfNeeded() {
   }
 }
 
-// Schedule the task to run at the top of every hour.  Adjust as needed.
 cron.schedule('0 * * * *', flipModeIfNeeded, {
   timezone: process.env.TIMEZONE || 'Australia/Sydney'
 });
 
 console.log('Mode scheduler started.  Checking prize mode hourly…');
-
-// Immediately check once on start
 flipModeIfNeeded();

--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "version": "1.0.0",
   "description": "Backend for the Freaky Friday Freaks2 game.  This service exposes a small HTTP API that wraps calls to the on‑chain FreakyFridayAuto contract.",
   "main": "ritual-relayer.js",
-  "type": "commonjs",
+  "type": "module",
   "scripts": {
     "start": "node ritual-relayer.js",
     "build:abi": "node build-abi.js",
     "bot": "node ritual-bot.js",
+    "bot:once": "ONE_SHOT=true node ritual-bot.js",
     "scheduler": "node mode-scheduler.js"
   },
   "dependencies": {

--- a/ritual-relayer.js
+++ b/ritual-relayer.js
@@ -1,51 +1,32 @@
-/*
-  ritual-relayer.js
-
-  This Express server wraps calls to the on‑chain FreakyFridayAuto contract.  It
-  exposes endpoints for joining a round via the relayer, checking the current
-  round status, closing an expired round, and performing batch refunds on
-  behalf of participants.
-
-  To run the server:
-
-    $ npm install
-    $ cp .env.example .env  # fill in RPC_URL, PRIVATE_KEY, FREAKY_ADDRESS, GCC_ADDRESS
-    $ npm start
-
-  See README.md for endpoint documentation.
-*/
-
-require('dotenv').config();
-const express = require('express');
-const cors    = require('cors');
-const { ethers } = require('ethers');
+import 'dotenv/config';
+import express from 'express';
+import cors from 'cors';
+import { ethers } from 'ethers';
 
 const app = express();
-const allowedOrigin = process.env.FRONTEND_URL || 'http://localhost:3000';
-app.use(cors({ origin: allowedOrigin }));
+const ORIGIN = process.env.FRONTEND_URL;
+app.use(cors({
+  origin: ORIGIN,
+  methods: ['GET','POST','OPTIONS'],
+  credentials: false,
+}));
 app.use(express.json());
 
-// Load ABIs.  These are generated from the JSON files in ./public by build-abi.js.
-const gameAbi = require('./public/freakyFridayGameAbi.json');
-const erc20Abi = require('./public/erc20Abi.json');
+import gameAbi from './public/freakyFridayGameAbi.json' assert { type: 'json' };
+import erc20Abi from './public/erc20Abi.json' assert { type: 'json' };
 
-// Initialise provider and signer
 const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
 const signer   = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
 
-// Construct contract instances
 const gameAddress = process.env.FREAKY_ADDRESS;
 const tokenAddress = process.env.GCC_TOKEN || process.env.GCC_ADDRESS;
 const gameContract = new ethers.Contract(gameAddress, gameAbi, signer);
 const tokenContract = new ethers.Contract(tokenAddress, erc20Abi, provider);
 
-// Utility: ensure an address is checksummed
 function normalizeAddress(addr) {
   try { return ethers.getAddress(addr); } catch (_) { return null; }
 }
 
-// GET /status
-// Returns current round state and configuration.
 app.get('/status', async (req, res) => {
   try {
     const [isActive, currentRound, roundStart, duration, entryAmount, roundMode, maxPlayers, participants] = await Promise.all([
@@ -54,7 +35,6 @@ app.get('/status', async (req, res) => {
       gameContract.roundStart(),
       gameContract.duration(),
       gameContract.entryAmount(),
-      // prefer explicit getter; fallback to public variable
       gameContract.getRoundMode ? gameContract.getRoundMode() : gameContract.roundMode(),
       gameContract.maxPlayers(),
       gameContract.getParticipants()
@@ -75,10 +55,6 @@ app.get('/status', async (req, res) => {
   }
 });
 
-// POST /relay-entry
-// Body: { user: "0x..." }
-// Registers a user for the current round.  Requires that the user has
-// approved the contract for at least entryAmount GCC.  The relayer pays gas.
 app.post('/relay-entry', async (req, res) => {
   try {
     const { user } = req.body;
@@ -86,7 +62,6 @@ app.post('/relay-entry', async (req, res) => {
     if (!addr) {
       return res.status(400).json({ error: 'Invalid user address' });
     }
-    // Check token allowance
     const [entryAmount, allowance] = await Promise.all([
       gameContract.entryAmount(),
       tokenContract.allowance(addr, gameAddress)
@@ -94,20 +69,15 @@ app.post('/relay-entry', async (req, res) => {
     if (allowance < entryAmount) {
       return res.status(400).json({ error: 'User allowance too low for entry' });
     }
-    // Call relayedEnter using the relayer signer
     const tx = await gameContract.relayedEnter(addr);
     await tx.wait();
     res.json({ success: true, txHash: tx.hash });
   } catch (err) {
-    // Extract revert reason if present
     let message = err?.error?.message || err?.message || String(err);
     res.status(500).json({ error: message });
   }
 });
 
-// POST /check-expired
-// Attempts to close the current round if duration has elapsed.  Anyone can call
-// this endpoint.  If the round is not active or not yet expired, returns an error.
 app.post('/check-expired', async (req, res) => {
   try {
     const [isActive, start, duration] = await Promise.all([
@@ -130,9 +100,6 @@ app.post('/check-expired', async (req, res) => {
   }
 });
 
-// POST /batch-refund
-// Body: { round: <number>, users: ["0x...", ...], maxCount?: <number> }
-// Allows the relayer to refund multiple users after a Standard round has closed.
 app.post('/batch-refund', async (req, res) => {
   try {
     const { round, users, maxCount } = req.body;
@@ -152,12 +119,10 @@ app.post('/batch-refund', async (req, res) => {
   }
 });
 
-// Fallback 404
 app.use((req, res) => {
   res.status(404).json({ error: 'Endpoint not found' });
 });
 
-// Start the server
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   console.log(`Freaks2 backend listening on port ${PORT}`);


### PR DESCRIPTION
## Summary
- refactor ritual-bot to safely close rounds via `staticCall` and log using Australia/Sydney timestamps
- tighten backend CORS config to honour a single frontend origin
- switch backend scripts to ESM modules and add a one-shot bot script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `ONE_SHOT=true RPC_URL=http://localhost PRIVATE_KEY=0x0 FREAKY_ADDRESS=0x0 node ritual-bot.js` *(fails: invalid BytesLike value)*
- `node build-abi.js`

------
https://chatgpt.com/codex/tasks/task_e_68a7ac7c90b8832b9b443b0076e1e406