### PR TITLE
Implement preflight checks and health endpoint

### DIFF
--- a/build-abi.js
+++ b/build-abi.js
@@ -14,6 +14,6 @@ if (fs.existsSync(abiFile)) {
   console.log("✅ ABI present:", abiFile);
   process.exit(0);
 } else {
-  console.error("❌ ABI missing. Please place freakyFridayGameAbi.json in /public before deploy.");
+  console.error("❌ ABI missing. Place freakyFridayGameAbi.json in /public before deploy.");
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- add build-time ABI presence check
- rewrite relayer with balance/allowance preflight, optional /health, and success hash response

## Testing
- `npm run build:abi`
- `node ritual-relayer.js` *(fails: Missing RPC_URL, PRIVATE_KEY, or FREAKY_ADDRESS)*

------
https://chatgpt.com/codex/tasks/task_e_68a813c248e4832b9a1be3d07a8fc53a