### PR TITLE
Add reliable round close scheduler and Friday mode switch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,5 @@
-# Core
 RPC_URL=https://bsc-dataseed.binance.org/
-FREAKY_ADDRESS=0x2a37F0325bcA2B71cF7f2189796Fb9BC1dEBc9C9
 PRIVATE_KEY=0xYOUR_PRIVATE_KEY
-
-# Bot
-CHECK_INTERVAL_SEC=30
-MIN_GAS_BNB=0.005
-
-# Node/Runtime
-NODE_ENV=production
+FREAKY_ADDRESS=0x2a37F0325bcA2B71cF7f2189796Fb9BC1dEBc9C9
+FRONTEND_URL=https://freaks2-frontend.onrender.com
+TZ=Australia/Sydney

--- a/abi/freakyFridayGameAbi.json
+++ b/abi/freakyFridayGameAbi.json
@@ -1,0 +1,729 @@
+
+  [
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "round",
+				"type": "uint256"
+			},
+			{
+				"internalType": "address[]",
+				"name": "users",
+				"type": "address[]"
+			},
+			{
+				"internalType": "uint256",
+				"name": "maxCount",
+				"type": "uint256"
+			}
+		],
+		"name": "batchClaimRefunds",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "checkTimeExpired",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "round",
+				"type": "uint256"
+			}
+		],
+		"name": "claimRefund",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "enter",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			}
+		],
+		"name": "fundBonus",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "_gcc",
+				"type": "address"
+			}
+		],
+		"stateMutability": "nonpayable",
+		"type": "constructor"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "token",
+				"type": "address"
+			}
+		],
+		"name": "SafeERC20FailedOperation",
+		"type": "error"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "caller",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			}
+		],
+		"name": "CloseTipPaid",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "user",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "round",
+				"type": "uint256"
+			}
+		],
+		"name": "Joined",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"internalType": "address",
+				"name": "sender",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			}
+		],
+		"name": "Received",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "user",
+				"type": "address"
+			},
+			{
+				"indexed": true,
+				"internalType": "uint256",
+				"name": "round",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			}
+		],
+		"name": "RefundClaimed",
+		"type": "event"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "user",
+				"type": "address"
+			}
+		],
+		"name": "relayedEnter",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"internalType": "address",
+				"name": "winner",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "round",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "prizePaid",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"internalType": "uint256",
+				"name": "refundPerPlayerFinal",
+				"type": "uint256"
+			}
+		],
+		"name": "RoundCompleted",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"internalType": "enum FreakyFridayAuto.PrizeMode",
+				"name": "newMode",
+				"type": "uint8"
+			}
+		],
+		"name": "RoundModeChanged",
+		"type": "event"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "newTip",
+				"type": "uint256"
+			}
+		],
+		"name": "setCloseTip",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "newAmt",
+				"type": "uint256"
+			}
+		],
+		"name": "setEntryAmount",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "newLimit",
+				"type": "uint256"
+			}
+		],
+		"name": "setMaxPlayers",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "_relayer",
+				"type": "address"
+			}
+		],
+		"name": "setRelayer",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "enum FreakyFridayAuto.PrizeMode",
+				"name": "newMode",
+				"type": "uint8"
+			}
+		],
+		"name": "setRoundMode",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address payable",
+				"name": "to",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			}
+		],
+		"name": "withdrawBNB",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "to",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "amount",
+				"type": "uint256"
+			}
+		],
+		"name": "withdrawLeftovers",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"stateMutability": "payable",
+		"type": "receive"
+	},
+	{
+		"inputs": [],
+		"name": "admin",
+		"outputs": [
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "checkBNBBalance",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "checkRewardBalance",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "closeTip",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "currentRound",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "duration",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "entryAmount",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "escrowedTokens",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "gcc",
+		"outputs": [
+			{
+				"internalType": "contract IERC20",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "getContractTokenBalance",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "getParticipants",
+		"outputs": [
+			{
+				"internalType": "address[]",
+				"name": "list",
+				"type": "address[]"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "getRoundMode",
+		"outputs": [
+			{
+				"internalType": "enum FreakyFridayAuto.PrizeMode",
+				"name": "",
+				"type": "uint8"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			},
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"name": "hasJoinedThisRound",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "isRoundActive",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "maxPlayers",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"name": "participants",
+		"outputs": [
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"name": "playersInRound",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			},
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"name": "refundClaimed",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"name": "refundPerPlayer",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "relayer",
+		"outputs": [
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "roundMode",
+		"outputs": [
+			{
+				"internalType": "enum FreakyFridayAuto.PrizeMode",
+				"name": "",
+				"type": "uint8"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"name": "roundModeAtClose",
+		"outputs": [
+			{
+				"internalType": "enum FreakyFridayAuto.PrizeMode",
+				"name": "",
+				"type": "uint8"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"name": "roundResolved",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "roundStart",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "totalReceivedThisRound",
+		"outputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint256",
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"name": "winnerOfRound",
+		"outputs": [
+			{
+				"internalType": "address",
+				"name": "",
+				"type": "address"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	}
+
+]

--- a/lib/contract.js
+++ b/lib/contract.js
@@ -1,0 +1,27 @@
+// CommonJS
+const { readFileSync } = require('fs');
+const { join } = require('path');
+const { ethers } = require('ethers');
+
+const abi = JSON.parse(readFileSync(join(__dirname, '..', 'abi', 'freakyFridayGameAbi.json'), 'utf8'));
+
+function getProvider() {
+  const rpc = process.env.RPC_URL;
+  if (!rpc) throw new Error('RPC_URL missing');
+  return new ethers.JsonRpcProvider(rpc);
+}
+
+function getSigner() {
+  const pk = process.env.PRIVATE_KEY;
+  if (!pk) throw new Error('PRIVATE_KEY missing');
+  return new ethers.Wallet(pk, getProvider());
+}
+
+function getGameContract(readOnly = false) {
+  const addr = process.env.FREAKY_ADDRESS;
+  if (!addr) throw new Error('FREAKY_ADDRESS missing');
+  const providerOrSigner = readOnly ? getProvider() : getSigner();
+  return new ethers.Contract(addr, abi, providerOrSigner);
+}
+
+module.exports = { getProvider, getSigner, getGameContract };

--- a/lib/mode.js
+++ b/lib/mode.js
@@ -1,0 +1,9 @@
+const { DateTime } = require('luxon');
+
+// Returns 'Jackpot' on Fridays in Australia/Sydney, else 'Standard'
+function desiredModeNow() {
+  const now = DateTime.now().setZone('Australia/Sydney');
+  return now.weekday === 5 ? 'Jackpot' : 'Standard'; // 5 = Friday
+}
+
+module.exports = { desiredModeNow };

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
   "name": "freaks2-backend",
   "version": "1.0.0",
-  "type": "module",
-  "engines": { "node": ">=20 <25" },
+  "main": "server.js",
+  "type": "commonjs",
+  "engines": { "node": ">=20" },
   "scripts": {
     "start": "node server.js",
-    "bot": "node ritual-bot.js",
-    "build:abi": "node build-abi.js",
-    "postinstall": "node build-abi.js"
+    "dev": "node server.js"
   },
   "dependencies": {
-    "cors": "^2.8.5",
     "dotenv": "^16.4.5",
-    "ethers": "^6.15.0",
-    "express": "^4.19.2"
+    "ethers": "^6.11.1",
+    "express": "^4.19.2",
+    "luxon": "^3.5.0",
+    "node-cron": "^3.0.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,34 +1,71 @@
-import 'dotenv/config';
-import express from 'express';
-import { ethers } from 'ethers';
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const abi = JSON.parse(fs.readFileSync(path.join(__dirname, './public/freakyFridayGameAbi.json'), 'utf8'));
+require('dotenv').config();
+const express = require('express');
+const cron = require('node-cron');
+const { tryCloseRound, syncPrizeMode } = require('./services/closer');
+const { getGameContract } = require('./lib/contract');
 
 const app = express();
 
+// Health
 app.get('/health', async (_req, res) => {
   try {
-    const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
-    const c = new ethers.Contract(process.env.FREAKY_ADDRESS, abi, provider);
-    const [chainId, active] = await Promise.all([
-      provider.getNetwork().then(n => n.chainId),
-      c.isRoundActive()
-    ]);
-    res.json({
-      ok: true,
-      contract: process.env.FREAKY_ADDRESS,
-      chainId,
-      isRoundActive: active
-    });
+    const game = getGameContract(true);
+    await game.currentRound(); // simple read
+    res.send('ok');
   } catch (e) {
-    res.status(500).json({ ok: false, error: e?.message || String(e) });
+    console.error(e);
+    res.status(500).send('bad');
   }
 });
 
-const port = process.env.PORT || 3000;
-app.listen(port, () => console.log(`Health on :${port}`));
+// Manual trigger (guarded and idempotent)
+app.get('/close/now', async (_req, res) => {
+  try {
+    const result = await tryCloseRound(console);
+    res.json(result);
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// Manual mode sync (optional)
+app.get('/mode/sync', async (_req, res) => {
+  try {
+    await syncPrizeMode(console);
+    res.json({ ok: true });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// --- Schedulers ---
+// 1) Regular heartbeat every 60s
+cron.schedule('* * * * *', async () => {
+  try { await tryCloseRound(console); } catch (e) { console.error(e); }
+});
+
+// 2) “Last two minutes” turbo: every 10s
+cron.schedule('*/10 * * * * *', async () => {
+  try {
+    const game = getGameContract(true);
+    if (!(await game.isRoundActive())) return;
+    const start = Number(await game.roundStart());
+    const dur   = Number(await game.duration());
+    const now   = Math.floor(Date.now()/1000);
+    const left  = start + dur - now;
+    if (left <= 120) await tryCloseRound(console);
+  } catch (e) { console.error(e); }
+});
+
+// 3) Mode sync every 10 minutes
+cron.schedule('*/10 * * * *', async () => {
+  try { await syncPrizeMode(console); } catch (e) { console.error(e); }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Freaks2 backend listening on ${PORT}`);
+  console.log(`Contract: ${process.env.FREAKY_ADDRESS}`);
+});

--- a/services/closer.js
+++ b/services/closer.js
@@ -1,0 +1,61 @@
+const { getGameContract } = require('../lib/contract');
+const { desiredModeNow } = require('../lib/mode');
+
+async function tryCloseRound(logger = console) {
+  const game = getGameContract(false);
+
+  const active = await game.isRoundActive();
+  if (!active) {
+    logger.info('[close] No active round.');
+    return { sent: false, reason: 'inactive' };
+  }
+
+  const round = Number(await game.currentRound());
+  const start = Number(await game.roundStart());
+  const dur   = Number(await game.duration());
+  const now   = Math.floor(Date.now() / 1000);
+  const left  = start + dur - now;
+
+  logger.info(`[close] round=${round} left=${left}`);
+
+  if (left > 0) {
+    return { sent: false, reason: 'too-early', left, round };
+  }
+
+  const count = (await game.getParticipants()).length;
+  logger.info(`[close] Closing round=${round}, participants=${count}`);
+
+  const tx = await game.checkTimeExpired();
+  logger.info(`[close] tx sent: ${tx.hash}`);
+  const rcpt = await tx.wait();
+  logger.info(`[close] tx confirmed in block ${rcpt.blockNumber}`);
+
+  return { sent: true, hash: tx.hash, round, count };
+}
+
+async function syncPrizeMode(logger = console) {
+  const game = getGameContract(false);
+  const active = await game.isRoundActive();
+  if (active) {
+    logger.info('[mode] Round active; skip mode change.');
+    return;
+  }
+
+  const want = desiredModeNow();
+  const enumIdx = want === 'Jackpot' ? 1 : 0;
+
+  if (game.getRoundMode) {
+    const cur = Number(await game.getRoundMode());
+    if (cur === enumIdx) return;
+  }
+
+  if (game.setRoundMode) {
+    const tx = await game.setRoundMode(enumIdx);
+    logger.info(`[mode] Set mode -> ${want}. Tx: ${tx.hash}`);
+    await tx.wait();
+  } else {
+    logger.warn('[mode] setRoundMode not available on this ABI.');
+  }
+}
+
+module.exports = { tryCloseRound, syncPrizeMode };


### PR DESCRIPTION
## Summary
- switch project to CommonJS and Node 20 friendly packaging
- add contract helpers and mode calculation for Friday Jackpot
- implement automatic round closer with manual `/close/now` endpoint and health check

## Testing
- `npm test` *(fails: Missing script "test")*
- `PORT=4000 RPC_URL=http://localhost:8545 PRIVATE_KEY=0x111... FREAKY_ADDRESS=0x2a37F... node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68a989b0b68c832b95f77035135f36a8