### PR TITLE
refactor: switch to commonjs and cron bot

### DIFF
--- a/check.js
+++ b/check.js
@@ -1,38 +1,39 @@
-// check.js (run with: node check.js 0xYOURWALLET)
-import { ethers } from "ethers";
-import fs from "fs";
+const { ethers } = require('ethers');
+const fs = require('fs');
 
-const RPC_URL = process.env.RPC_URL || "https://bsc-dataseed.binance.org/";
-const GAME = "0x2a37F0325bcA2B71cF7f2189796Fb9BC1dEBc9C9";
-const ABI = JSON.parse(fs.readFileSync("./public/freakyFridayGameAbi.json", "utf8"));
+const RPC_URL = process.env.RPC_URL || 'https://bsc-dataseed.binance.org/';
+const GAME = '0x2a37F0325bcA2B71cF7f2189796Fb9BC1dEBc9C9';
+const ABI = JSON.parse(fs.readFileSync('./public/freakyFridayGameAbi.json', 'utf8'));
 
 const erc20Min = [
-  "function allowance(address owner, address spender) view returns (uint256)",
-  "function balanceOf(address) view returns (uint256)",
-  "function decimals() view returns (uint8)"
+  'function allowance(address owner, address spender) view returns (uint256)',
+  'function balanceOf(address) view returns (uint256)',
+  'function decimals() view returns (uint8)'
 ];
 
 const user = process.argv[2];
-if (!user) throw new Error("Provide user address, e.g. node check.js 0x...");
+if (!user) throw new Error('Provide user address, e.g. node check.js 0x...');
 
 const provider = new ethers.JsonRpcProvider(RPC_URL);
 
-const game = new ethers.Contract(GAME, ABI, provider);
-const tokenAddr = await game.gcc();
-const token = new ethers.Contract(tokenAddr, erc20Min, provider);
+(async () => {
+  const game = new ethers.Contract(GAME, ABI, provider);
+  const tokenAddr = await game.gcc();
+  const token = new ethers.Contract(tokenAddr, erc20Min, provider);
 
-const [dec, entry, bal, allow] = await Promise.all([
-  token.decimals(),
-  game.entryAmount(),
-  token.balanceOf(user),
-  token.allowance(user, await game.getAddress())
-]);
+  const [dec, entry, bal, allow] = await Promise.all([
+    token.decimals(),
+    game.entryAmount(),
+    token.balanceOf(user),
+    token.allowance(user, await game.getAddress())
+  ]);
 
-console.log({
-  token: tokenAddr,
-  decimals: dec,
-  entryRaw: entry.toString(),
-  entryHuman: ethers.formatUnits(entry, dec),
-  balanceHuman: ethers.formatUnits(bal, dec),
-  allowanceHuman: ethers.formatUnits(allow, dec)
-});
+  console.log({
+    token: tokenAddr,
+    decimals: dec,
+    entryRaw: entry.toString(),
+    entryHuman: ethers.formatUnits(entry, dec),
+    balanceHuman: ethers.formatUnits(bal, dec),
+    allowanceHuman: ethers.formatUnits(allow, dec)
+  });
+})();

--- a/mode-scheduler.js
+++ b/mode-scheduler.js
@@ -1,7 +1,11 @@
-import 'dotenv/config';
-import { DateTime } from 'luxon';
-import { ethers } from 'ethers';
-import gameAbi from './public/freakyFridayGameAbi.json' assert { type: 'json' };
+require('dotenv').config();
+const { DateTime } = require('luxon');
+const { ethers } = require('ethers');
+const fs = require('fs');
+const path = require('path');
+
+const abiPath = path.join(__dirname, 'public', 'freakyFridayGameAbi.json');
+const gameAbi = JSON.parse(fs.readFileSync(abiPath, 'utf8'));
 
 const { RPC_URL, PRIVATE_KEY, FREAKY_CONTRACT, FREAKY_ADDRESS } = process.env;
 const CONTRACT = (FREAKY_ADDRESS || FREAKY_CONTRACT || '0x2a37F0325bcA2B71cF7f2189796Fb9BC1dEBc9C9').trim();
@@ -10,7 +14,7 @@ const provider = new ethers.JsonRpcProvider(RPC_URL);
 const signer   = new ethers.Wallet(PRIVATE_KEY, provider);
 const game     = new ethers.Contract(CONTRACT, gameAbi, signer);
 
-export default async function switchMode(target) {
+async function switchMode(target) {
   try {
     const active = await game.isRoundActive();
     if (active) {
@@ -44,3 +48,5 @@ export default async function switchMode(target) {
     console.error('mode switch error:', err.reason || err.message || err);
   }
 }
+
+module.exports = switchMode;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "uuid": "8.3.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20 <25"
       }
     },
     "node_modules/@adraffy/ens-normalize": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,11 @@
 {
   "name": "freaks2-backend",
   "version": "1.0.0",
-  "type": "module",
-  "engines": { "node": ">=20" },
+  "engines": { "node": ">=20 <25" },
   "scripts": {
-    "build:abi": "node build-abi.js",
     "start": "node ritual-relayer.js",
     "bot": "node ritual-bot.js",
-    "mode:switch": "node mode-scheduler.js"
+    "build:abi": "node build-abi.js"
   },
   "dependencies": {
     "dotenv": "^16.4.5",


### PR DESCRIPTION
## Summary
- switch backend to CommonJS and load ABI via fs
- add cron-based ritual bot and optional mode scheduler
- pin Node engine to >=20 <25

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a9b2f886d0832bae1b4b06012f504d