### PR TITLE
Close rounds on time and add Friday mode control

### DIFF
--- a/cron-close-and-arm.js
+++ b/cron-close-and-arm.js
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import { ethers } from 'ethers';
+
+const ABI = JSON.parse(fs.readFileSync('./public/freakyFridayGameAbi.json','utf8')); // <- no import assert
+const RPC = process.env.RPC_URL;
+const PK  = process.env.RELAYER_PK;
+const GAME = process.env.FREAKY_CONTRACT;
+
+const provider = new ethers.JsonRpcProvider(RPC);
+const wallet   = new ethers.Wallet(PK, provider);
+const game     = new ethers.Contract(GAME, ABI, wallet);
+
+async function closeIfEnded() {
+  const active = await game.isRoundActive();
+  if (!active) return false;
+  const start = Number(await game.roundStart());
+  const dur   = Number(await game.duration());
+  const now   = Math.floor(Date.now()/1000);
+  if (now >= start + dur) {
+    const tx = await game.checkTimeExpired();
+    console.log('[close] tx', tx.hash);
+    await tx.wait();
+    return true;
+  }
+  return false;
+}
+
+async function armIfInactive() {
+  const active = await game.isRoundActive();
+  if (active) return false;
+
+  const me = await wallet.getAddress();
+  // Pre-req (one-time, off-chain): relayer has GCC and has approved GAME to spend entryAmount
+  const tx = await game.relayedEnter(me);
+  console.log('[arm] tx', tx.hash);
+  await tx.wait();
+  return true;
+}
+
+(async () => {
+  const closed = await closeIfEnded();
+  const armed  = await armIfInactive();
+  console.log(JSON.stringify({ closed, armed }, null, 2));
+})().catch(e => { console.error(e); process.exit(1); });

--- a/cron-set-mode.js
+++ b/cron-set-mode.js
@@ -1,0 +1,23 @@
+import fs from 'node:fs';
+import { ethers } from 'ethers';
+
+const ABI = JSON.parse(fs.readFileSync('./public/freakyFridayGameAbi.json','utf8'));
+const RPC = process.env.RPC_URL;
+const PK  = process.env.RELAYER_PK;
+const GAME= process.env.FREAKY_CONTRACT;
+const provider = new ethers.JsonRpcProvider(RPC);
+const wallet   = new ethers.Wallet(PK, provider);
+const game     = new ethers.Contract(GAME, ABI, wallet);
+
+const arg = (process.argv[2]||'').toLowerCase(); // "on" or "off"
+const target = arg === 'on' ? 1 : 0;
+
+(async () => {
+  const cur = Number(await game.getRoundMode());
+  if (cur !== target) {
+    const tx = await game.setRoundMode(target);
+    console.log('[mode] tx', tx.hash);
+    await tx.wait();
+  }
+  console.log('[mode] now =', await game.getRoundMode());
+})().catch(e => { console.error(e); process.exit(1); });

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "start": "node ritual-relayer.js",
-    "bot": "node ritual-relayer.js"
+    "bot": "node cron-close-and-arm.js",
+    "bot:friOn": "node cron-set-mode.js on",
+    "bot:friOff": "node cron-set-mode.js off"
   },
   "dependencies": {
     "dotenv": "^16.4.5",


### PR DESCRIPTION
## Summary
- replace JSON import with fs loading in a new `cron-close-and-arm.js`
- add optional Friday mode flipper in `cron-set-mode.js`
- update scripts in `package.json` to run new cron tasks

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa8653af74832b9a99fcf3d15c2267