### PR TITLE
feat: add env helper and harden cron scripts

### DIFF
--- a/cron-close-and-arm.js
+++ b/cron-close-and-arm.js
@@ -1,44 +1,72 @@
 import fs from 'node:fs';
 import { ethers } from 'ethers';
+import { getEnv } from './env.js';
 
-const ABI = JSON.parse(fs.readFileSync('./public/freakyFridayGameAbi.json','utf8')); // <- no import assert
-const RPC = process.env.RPC_URL;
-const PK  = process.env.RELAYER_PK;
-const GAME = process.env.FREAKY_CONTRACT;
+const ABI = JSON.parse(fs.readFileSync('./public/freakyFridayGameAbi.json', 'utf8'));
+const { RPC_URL, FREAKY_CONTRACT, PK, missing } = getEnv();
 
-const provider = new ethers.JsonRpcProvider(RPC);
-const wallet   = new ethers.Wallet(PK, provider);
-const game     = new ethers.Contract(GAME, ABI, wallet);
+if (missing.length) {
+  console.error('❌ Missing env:', missing.join(', '));
+  process.exit(1);
+}
+
+let wallet;
+let game;
+try {
+  const provider = new ethers.JsonRpcProvider(RPC_URL);
+  wallet = new ethers.Wallet(PK, provider);
+  game = new ethers.Contract(FREAKY_CONTRACT, ABI, wallet);
+} catch (e) {
+  console.error('❌ Failed to init wallet. Check PRIVATE_KEY/RELAYER_PK format.', e?.shortMessage || e);
+  process.exit(1);
+}
 
 async function closeIfEnded() {
-  const active = await game.isRoundActive();
-  if (!active) return false;
-  const start = Number(await game.roundStart());
-  const dur   = Number(await game.duration());
-  const now   = Math.floor(Date.now()/1000);
-  if (now >= start + dur) {
-    const tx = await game.checkTimeExpired();
-    console.log('[close] tx', tx.hash);
-    await tx.wait();
-    return true;
+  const active = await game.isRoundActive().catch(() => false);
+  if (!active) {
+    console.log('ℹ️ Round inactive; nothing to close this tick.');
+    return false;
   }
-  return false;
+
+  const start = Number(await game.roundStart());
+  const dur = Number(await game.duration());
+  const now = Math.floor(Date.now() / 1000);
+  if (now < start + dur) {
+    console.log(`ℹ️ Round active, ${start + dur - now}s remaining; skipping close.`);
+    return false;
+  }
+
+  console.log('→ close: calling checkTimeExpired()');
+  const tx = await game.checkTimeExpired();
+  console.log('  tx:', tx.hash);
+  await tx.wait();
+  console.log('✅ close: RoundCompleted mined');
+  return true;
 }
 
 async function armIfInactive() {
-  const active = await game.isRoundActive();
-  if (active) return false;
+  const active = await game.isRoundActive().catch(() => false);
+  if (active) {
+    console.log('ℹ️ Round active; nothing to arm.');
+    return false;
+  }
 
   const me = await wallet.getAddress();
+  console.log(`→ arm: calling relayedEnter(${me})`);
   // Pre-req (one-time, off-chain): relayer has GCC and has approved GAME to spend entryAmount
   const tx = await game.relayedEnter(me);
-  console.log('[arm] tx', tx.hash);
+  console.log('  tx:', tx.hash);
   await tx.wait();
+  console.log('✅ arm: relayedEnter mined');
   return true;
 }
 
 (async () => {
   const closed = await closeIfEnded();
-  const armed  = await armIfInactive();
+  const armed = await armIfInactive();
   console.log(JSON.stringify({ closed, armed }, null, 2));
-})().catch(e => { console.error(e); process.exit(1); });
+  process.exit(0);
+})().catch(e => {
+  console.error('❌ cron error', e?.shortMessage || e);
+  process.exit(1);
+});

--- a/cron-set-mode.js
+++ b/cron-set-mode.js
@@ -1,13 +1,25 @@
 import fs from 'node:fs';
 import { ethers } from 'ethers';
+import { getEnv } from './env.js';
 
-const ABI = JSON.parse(fs.readFileSync('./public/freakyFridayGameAbi.json','utf8'));
-const RPC = process.env.RPC_URL;
-const PK  = process.env.RELAYER_PK;
-const GAME= process.env.FREAKY_CONTRACT;
-const provider = new ethers.JsonRpcProvider(RPC);
-const wallet   = new ethers.Wallet(PK, provider);
-const game     = new ethers.Contract(GAME, ABI, wallet);
+const ABI = JSON.parse(fs.readFileSync('./public/freakyFridayGameAbi.json', 'utf8'));
+const { RPC_URL, FREAKY_CONTRACT, PK, missing } = getEnv();
+
+if (missing.length) {
+  console.error('❌ Missing env:', missing.join(', '));
+  process.exit(1);
+}
+
+let wallet;
+let game;
+try {
+  const provider = new ethers.JsonRpcProvider(RPC_URL);
+  wallet = new ethers.Wallet(PK, provider);
+  game = new ethers.Contract(FREAKY_CONTRACT, ABI, wallet);
+} catch (e) {
+  console.error('❌ Failed to init wallet. Check PRIVATE_KEY/RELAYER_PK format.', e?.shortMessage || e);
+  process.exit(1);
+}
 
 const arg = (process.argv[2]||'').toLowerCase(); // "on" or "off"
 const target = arg === 'on' ? 1 : 0;
@@ -15,9 +27,17 @@ const target = arg === 'on' ? 1 : 0;
 (async () => {
   const cur = Number(await game.getRoundMode());
   if (cur !== target) {
+    console.log(`→ mode: setRoundMode(${target})`);
     const tx = await game.setRoundMode(target);
-    console.log('[mode] tx', tx.hash);
+    console.log('  tx:', tx.hash);
     await tx.wait();
+    console.log('✅ mode: setRoundMode mined');
+  } else {
+    console.log('ℹ️ Mode already set; nothing to do.');
   }
   console.log('[mode] now =', await game.getRoundMode());
-})().catch(e => { console.error(e); process.exit(1); });
+  process.exit(0);
+})().catch(e => {
+  console.error('❌ cron error', e?.shortMessage || e);
+  process.exit(1);
+});

--- a/env.js
+++ b/env.js
@@ -1,0 +1,22 @@
+// Environment helper for relayer scripts
+// Normalizes variable names and ensures required values are present
+
+export function getEnv() {
+  const RPC_URL = process.env.RPC_URL || process.env.RPC || '';
+  const FREAKY_CONTRACT = process.env.FREAKY_CONTRACT || process.env.FREAKY_ADDRESS || '';
+
+  // Accept both PRIVATE_KEY and RELAYER_PK for backwards compatibility
+  let PK = (process.env.PRIVATE_KEY || process.env.RELAYER_PK || '').trim();
+
+  // Strip accidental quotes / whitespace / 0x duplication
+  PK = PK.replace(/^['"]|['"]$/g, '').trim();
+  if (PK && !PK.startsWith('0x')) PK = '0x' + PK;
+
+  const missing = [];
+  if (!RPC_URL) missing.push('RPC_URL');
+  if (!FREAKY_CONTRACT) missing.push('FREAKY_CONTRACT');
+  if (!PK) missing.push('PRIVATE_KEY|RELAYER_PK');
+
+  return { RPC_URL, FREAKY_CONTRACT, PK, missing };
+}
+

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "bot": "node cron-close-and-arm.js",
+    "bot": "node ritual-relayer.js",
     "bot:friOn": "node cron-set-mode.js on",
     "bot:friOff": "node cron-set-mode.js off"
   },

--- a/ritual-relayer.js
+++ b/ritual-relayer.js
@@ -1,25 +1,29 @@
 import fs from 'fs';
 import { DateTime } from 'luxon';
 import { ethers } from 'ethers';
+import { getEnv } from './env.js';
 
-const {
-  RPC_URL,
-  RELAYER_PK,
-  FREAKY_CONTRACT,
-  JACKPOT_TZ = 'Australia/Sydney'
-} = process.env;
+const { RPC_URL, FREAKY_CONTRACT, PK, missing } = getEnv();
+const JACKPOT_TZ = process.env.JACKPOT_TZ || 'Australia/Sydney';
 
-if (!RPC_URL || !RELAYER_PK || !FREAKY_CONTRACT) {
-  console.error('Missing env: RPC_URL / RELAYER_PK / FREAKY_CONTRACT');
+if (missing.length) {
+  console.error('❌ Missing env:', missing.join(', '));
   process.exit(1);
 }
 
 // Load ABI without JSON assert (Render Node v24 quirk)
 const gameAbi = JSON.parse(fs.readFileSync('./public/freakyFridayGameAbi.json', 'utf8'));
 
-const provider = new ethers.JsonRpcProvider(RPC_URL);
-const wallet   = new ethers.Wallet(RELAYER_PK, provider);
-const game     = new ethers.Contract(FREAKY_CONTRACT, gameAbi, wallet);
+let wallet;
+let game;
+try {
+  const provider = new ethers.JsonRpcProvider(RPC_URL);
+  wallet = new ethers.Wallet(PK, provider);
+  game = new ethers.Contract(FREAKY_CONTRACT, gameAbi, wallet);
+} catch (e) {
+  console.error('❌ Failed to init wallet. Check PRIVATE_KEY/RELAYER_PK format.', e?.shortMessage || e);
+  process.exit(1);
+}
 
 function isFridaySydney(tsSec) {
   const dt = DateTime.fromSeconds(tsSec, { zone: JACKPOT_TZ });
@@ -30,39 +34,42 @@ async function run() {
   try {
     const active = await game.isRoundActive();
 
-    // If idle, set mode based on Sydney Friday
+    // If idle, ensure mode based on Sydney Friday
     if (!active) {
-      const target = isFridaySydney(Math.floor(Date.now()/1000)) ? 1 : 0; // 0=Standard, 1=Jackpot
+      const target = isFridaySydney(Math.floor(Date.now() / 1000)) ? 1 : 0; // 0=Standard, 1=Jackpot
       if (typeof game.getRoundMode === 'function') {
         const current = Number(await game.getRoundMode());
         if (current !== target && typeof game.setRoundMode === 'function') {
+          console.log(`→ mode: setRoundMode(${target})`);
           const tx = await game.setRoundMode(target);
-          console.log(`[mode] setRoundMode(${target}) tx=${tx.hash}`);
+          console.log('  tx:', tx.hash);
           await tx.wait();
+          console.log('✅ mode: setRoundMode mined');
         }
       }
-      console.log('[cron] idle; mode ensured; exit 0');
+      console.log('ℹ️ Round inactive; nothing to close this tick.');
       process.exit(0);
     }
 
     // If active, close when expired
-    const start    = Number(await game.roundStart());
+    const start = Number(await game.roundStart());
     const duration = Number(await game.duration());
-    const endTs    = start + duration;
-    const now      = Math.floor(Date.now()/1000);
+    const endTs = start + duration;
+    const now = Math.floor(Date.now() / 1000);
 
     if (now < endTs) {
-      console.log(`[cron] round active, ${endTs - now}s remaining; exit 0`);
+      console.log(`ℹ️ Round active, ${endTs - now}s remaining; nothing to close.`);
       process.exit(0);
     }
 
+    console.log('→ close: calling checkTimeExpired()');
     const tx = await game.checkTimeExpired();
-    console.log(`[close] checkTimeExpired tx=${tx.hash}`);
+    console.log('  tx:', tx.hash);
     const rcpt = await tx.wait();
-    console.log(`[close] mined block ${rcpt.blockNumber}`);
+    console.log(`✅ close: RoundCompleted mined (block ${rcpt.blockNumber})`);
     process.exit(0);
   } catch (e) {
-    console.error('❌ cron error', e);
+    console.error('❌ cron error', e?.shortMessage || e);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- normalize env var names and sanitize relayer private key
- validate env vars and improve logging across cron scripts
- run relayer via `npm run bot`

## Testing
- `npm test` *(fails: Missing script)*
- `node ritual-relayer.js` *(fails: Missing env: RPC_URL, FREAKY_CONTRACT, PRIVATE_KEY|RELAYER_PK)*

------
https://chatgpt.com/codex/tasks/task_e_68aa91415340832b97d9c6fc0f8ae1ba